### PR TITLE
chore: add renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>zextras/infra-renovate-config:default"]
+  "extends": [
+    "github>zextras/infra-renovate-config"
+  ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>zextras/infra-renovate-config:default"]
+}

--- a/videoserver/ffmpeg/PKGBUILD
+++ b/videoserver/ffmpeg/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname="carbonio-ffmpeg"
-pkgver="4.4.5"
+pkgver="4.4.5" # renovate: datasource=github-releases depName=FFmpeg/FFmpeg
 pkgrel="1"
 pkgdesc="Complete solution to record, convert and stream audio and video"
 arch=('x86_64')

--- a/videoserver/libev/PKGBUILD
+++ b/videoserver/libev/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname="carbonio-libev"
-pkgver="4.33"
+pkgver="4.33" # renovate: datasource=repology depName=libev
 pkgrel="2"
 pkgdesc="A full-featured and high-performance event loop"
 arch=('x86_64')

--- a/videoserver/libfdk-aac/PKGBUILD
+++ b/videoserver/libfdk-aac/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname="carbonio-libfdk-aac"
-pkgver="2.0.2"
+pkgver="2.0.2" # renovate: datasource=github-releases depName=mstorsjo/fdk-aac
 pkgrel="2"
 pkgdesc="Fraunhofer FDK AAC codec library"
 arch=('x86_64')

--- a/videoserver/libnice/PKGBUILD
+++ b/videoserver/libnice/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname="carbonio-libnice"
-pkgver="0.1.22"
+pkgver="0.1.22" # renovate: datasource=github-releases depName=libnice/libnice
 pkgrel="2"
 pkgdesc="An implementation of the IETF's draft ICE (for p2p UDP data streams)"
 arch=('x86_64')

--- a/videoserver/libopus/PKGBUILD
+++ b/videoserver/libopus/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname="carbonio-libopus"
-pkgver="1.3.1"
+pkgver="1.3.1" # renovate: datasource=repology depName=opus
 pkgrel="2"
 pkgdesc="Totally open, royalty-free, highly versatile audio codec"
 arch=('x86_64')

--- a/videoserver/librabbitmq-c/PKGBUILD
+++ b/videoserver/librabbitmq-c/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname="carbonio-librabbitmq-c"
-pkgver="0.11.0"
+pkgver="0.11.0" # renovate: datasource=github-releases depName=alanxz/rabbitmq-c
 pkgrel="2"
 pkgdesc="RabbitMQ(amqp) library written in C-language"
 arch=('x86_64')

--- a/videoserver/libsrtp/PKGBUILD
+++ b/videoserver/libsrtp/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname="carbonio-libsrtp"
-pkgver="2.4.2"
+pkgver="2.4.2" # renovate: datasource=github-releases depName=cisco/libsrtp
 pkgrel="3"
 pkgdesc="Library for SRTP (Secure Realtime Transport Protocol)"
 arch=('x86_64')

--- a/videoserver/libusrsctp/PKGBUILD
+++ b/videoserver/libusrsctp/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname="carbonio-libusrsctp"
-pkgver="0.9.5.0"
+pkgver="0.9.5.0" # renovate: datasource=github-releases depName=sctplab/usrsctp
 pkgrel="2"
 pkgdesc="A portable SCTP userland stack"
 arch=('x86_64')

--- a/videoserver/libuv/PKGBUILD
+++ b/videoserver/libuv/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname="carbonio-libuv"
-pkgver="1.44.2"
+pkgver="1.44.2" # renovate: datasource=github-releases depName=libuv/libuv
 pkgrel="2"
 pkgdesc="Multi-platform support library with a focus on asynchronous I/O"
 arch=('x86_64')

--- a/videoserver/libvpx/PKGBUILD
+++ b/videoserver/libvpx/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname="carbonio-libvpx"
-pkgver="1.13.1"
+pkgver="1.13.1" # renovate: datasource=github-releases depName=webmproject/libvpx
 pkgrel="1"
 pkgdesc="VP8 and VP9 codec"
 arch=('x86_64')

--- a/videoserver/libwebsockets/PKGBUILD
+++ b/videoserver/libwebsockets/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname="carbonio-libwebsockets"
-pkgver="4.3.3"
+pkgver="4.3.3" # renovate: datasource=github-releases depName=warmcat/libwebsockets
 pkgrel="1"
 pkgdesc="C library for websocket clients and servers"
 arch=('x86_64')

--- a/videoserver/mlt/PKGBUILD
+++ b/videoserver/mlt/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=carbonio-mlt
-pkgver=6.26.1
+pkgver=6.26.1 # renovate: datasource=github-releases depName=mltframework/mlt
 pkgrel=2
 pkgdesc='An open source multimedia framework'
 arch=('x86_64')

--- a/videoserver/x264/PKGBUILD
+++ b/videoserver/x264/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname="carbonio-x264"
-pkgver="0.164.r3108"
+pkgver="0.164.r3108" # renovate: datasource=gitlab-tags depName=videolan/x264
 pkgrel="1"
 pkgdesc="Open Source H264/AVC video encoder"
 arch=('x86_64')


### PR DESCRIPTION
## Summary

This PR migrates the repository to use Renovate for automated dependency management.

## Changes

- Add Renovate configuration based on detected tech stack
- Remove Dependabot configuration (if present)
- Configure automated dependency updates according to Zextras standards

## Tech Stack Detected

The configuration has been tailored for the technologies detected in this repository.

## Benefits

- Centralized dependency management configuration
- Better grouping of related dependency updates
- More flexible scheduling and update strategies
- Improved security vulnerability handling

Refs: IN-948