### PR TITLE
fix(pkgbuild): add missing makedepends and reproducibility flags

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 library(
-    identifier: 'jenkins-lib-common@1.1.2',
+    identifier: 'jenkins-lib-common@1.5.0',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',
@@ -43,65 +43,11 @@ pipeline {
     stage('Build deb/rpm') {
       steps {
         echo 'Building deb/rpm packages'
-        withCredentials([
-          usernamePassword(
-            credentialsId: 'artifactory-jenkins-gradle-properties-splitted',
-            passwordVariable: 'SECRET',
-            usernameVariable: 'USERNAME'
-          )
-        ]) {
-          script {
-            env.REPO_ENV = env.GIT_TAG ? 'rc' : 'devel'
-          }
-
-          buildStage([
-            overrides: [
-              'ubuntu-jammy': [
-                preBuildScript: '''
-                  echo "machine zextras.jfrog.io" >> auth.conf
-                  echo "login ''' + USERNAME + '''" >> auth.conf
-                  echo "password ''' + SECRET + '''" >> auth.conf
-                  mv auth.conf /etc/apt
-                  echo "deb [trusted=yes] https://zextras.jfrog.io/artifactory/ubuntu-''' + env.REPO_ENV + ''' jammy main" > zextras.list
-                  mv *.list /etc/apt/sources.list.d/
-                '''
-              ],
-              'ubuntu-noble': [
-                preBuildScript: '''
-                  echo "machine zextras.jfrog.io" >> auth.conf
-                  echo "login ''' + USERNAME + '''" >> auth.conf
-                  echo "password ''' + SECRET + '''" >> auth.conf
-                  mv auth.conf /etc/apt
-                  echo "deb [trusted=yes] https://zextras.jfrog.io/artifactory/ubuntu-''' + env.REPO_ENV + ''' noble main" > zextras.list
-                  mv *.list /etc/apt/sources.list.d/
-                '''
-              ],
-              'rocky-8': [
-                prepare: true,
-                preBuildScript: '''
-                  echo "[Zextras]" > zextras.repo
-                  echo "name=Zextras" >> zextras.repo
-                  echo "baseurl=https://''' + USERNAME + ':' + SECRET + '''@zextras.jfrog.io/artifactory/centos8-''' + env.REPO_ENV + '''/" >> zextras.repo
-                  echo "enabled=1" >> zextras.repo
-                  echo "gpgcheck=0" >> zextras.repo
-                  echo "gpgkey=https://''' + USERNAME + ':' + SECRET + '''@zextras.jfrog.io/artifactory/centos8-''' + env.REPO_ENV + '''/repomd.xml.key" >> zextras.repo
-                  mv *.repo /etc/yum.repos.d/
-                ''',
-              ],
-              'rocky-9': [
-                prepare: true,
-                preBuildScript: '''
-                  echo "[Zextras]" > zextras.repo
-                  echo "name=Zextras" >> zextras.repo
-                  echo "baseurl=https://''' + USERNAME + ':' + SECRET + '''@zextras.jfrog.io/artifactory/rhel9-''' + env.REPO_ENV + '''/" >> zextras.repo
-                  echo "enabled=1" >> zextras.repo
-                  echo "gpgcheck=0" >> zextras.repo
-                  mv *.repo /etc/yum.repos.d/
-                ''',
-              ],
-            ]
-          ])
-        }
+        buildStage(
+          addCarbonioRepos: true,
+          carbonioRepoCredentialId: 'artifactory-jenkins-gradle-properties-splitted',
+          prepare: true,
+        )
       }
       post {
         failure {

--- a/videoserver/ffmpeg/PKGBUILD
+++ b/videoserver/ffmpeg/PKGBUILD
@@ -29,6 +29,7 @@ makedepends__apt=(
   "libmp3lame-dev"
   "libtheora-dev"
   "libxcb1-dev"
+  "nasm"
 )
 depends__yum=(
   "carbonio-libfdk-aac"
@@ -48,6 +49,7 @@ makedepends__yum=(
   "libass-devel"
   "libtheora-devel"
   "libxcb-devel"
+  "nasm"
   "zlib-devel"
 )
 
@@ -60,6 +62,7 @@ sha256sums=('77e0eedd8ebeafde5807011e700fdea82b306b9f76fe469b4abc5dfefd9579bd')
 
 build() {
   cd "${srcdir}/ffmpeg-${pkgver}"
+  export CFLAGS="${CFLAGS} -ffile-prefix-map=${srcdir}=."
   export LDFLAGS="-Wl,-rpath,/opt/zextras/common/lib"
   export PKG_CONFIG_PATH="/opt/zextras/common/lib/pkgconfig"
 
@@ -83,7 +86,7 @@ build() {
     --extra-cflags="-I/opt/zextras/common/include" \
     --extra-ldflags="-L/opt/zextras/common/lib" \
     --prefix=/opt/zextras/common
-  make -j8
+  make -j"$(( $(nproc) / 2 ))"
 }
 
 package() {

--- a/videoserver/libev/PKGBUILD
+++ b/videoserver/libev/PKGBUILD
@@ -26,10 +26,11 @@ sha256sums=('507eb7b8d1015fbec5b935f34ebed15bf346bed04a11ab82b8eee848c4205aea')
 
 build() {
   cd "${srcdir}/libev-${pkgver}"
+  export CFLAGS="${CFLAGS} -ffile-prefix-map=${srcdir}=."
   export LDFLAGS="-Wl,-rpath,/opt/zextras/common/lib"
   export PKG_CONFIG_PATH="/opt/zextras/common/lib/pkgconfig"
   ./configure --prefix=/opt/zextras/common
-  make -j8
+  make -j"$(( $(nproc) / 2 ))"
 }
 
 package() {

--- a/videoserver/libfdk-aac/PKGBUILD
+++ b/videoserver/libfdk-aac/PKGBUILD
@@ -11,10 +11,12 @@ maintainer="Zextras <packages@zextras.com"
 url="https://zextras.com"
 makedepends__apt=(
   "autoconf"
+  "automake"
   "libtool-bin"
 )
 makedepends__yum=(
   "autoconf"
+  "automake"
   "libtool"
 )
 section="libs"
@@ -26,13 +28,15 @@ sha256sums=('7812b4f0cf66acda0d0fe4302545339517e702af7674dd04e5fe22a5ade16a90')
 
 build() {
   cd "${srcdir}/fdk-aac-${pkgver}"
+  export CFLAGS="${CFLAGS} -ffile-prefix-map=${srcdir}=."
+  export CXXFLAGS="${CXXFLAGS} -ffile-prefix-map=${srcdir}=."
   export LDFLAGS="-Wl,-rpath,/opt/zextras/common/lib"
 
   ./autogen.sh
   ./configure \
     --prefix=/opt/zextras/common \
     --disable-static
-  make -j8
+  make -j"$(( $(nproc) / 2 ))"
 }
 
 package() {

--- a/videoserver/libnice/PKGBUILD
+++ b/videoserver/libnice/PKGBUILD
@@ -13,12 +13,12 @@ depends__apt=(
   "carbonio-openssl"
 )
 makedepends__apt=(
-  "carbonio-openssl"
+  "libglib2.0-dev"
   "ninja-build"
   "python3-pip"
 )
 makedepends__ubuntu_noble=(
-  "carbonio-openssl"
+  "libglib2.0-dev"
   "meson"
   "ninja-build"
 )
@@ -26,7 +26,7 @@ depends__yum=(
   "carbonio-openssl"
 )
 makedepends__yum=(
-  "carbonio-openssl"
+  "glib2-devel"
   "meson"
   "ninja-build"
 )
@@ -39,6 +39,7 @@ sha256sums=('3048b847fd89f43474c1a77257c875a85e4d85c879d12743f3ce2947125eb8de')
 
 build__apt() {
   cd "${srcdir}/libnice-${pkgver}"
+  export CFLAGS="${CFLAGS} -ffile-prefix-map=${srcdir}=."
   export PKG_CONFIG_PATH="/opt/zextras/common/lib/pkgconfig"
   pip3 install meson
   meson \
@@ -50,6 +51,7 @@ build__apt() {
 
 build__ubuntu_noble() {
   cd "${srcdir}/libnice-${pkgver}"
+  export CFLAGS="${CFLAGS} -ffile-prefix-map=${srcdir}=."
   export PKG_CONFIG_PATH="/opt/zextras/common/lib/pkgconfig"
   meson \
     --libdir=lib \
@@ -60,6 +62,7 @@ build__ubuntu_noble() {
 
 build__yum() {
   cd "${srcdir}/libnice-${pkgver}"
+  export CFLAGS="${CFLAGS} -ffile-prefix-map=${srcdir}=."
   export PKG_CONFIG_PATH="/opt/zextras/common/lib/pkgconfig"
   meson \
     --libdir=lib \

--- a/videoserver/libopus/PKGBUILD
+++ b/videoserver/libopus/PKGBUILD
@@ -11,6 +11,11 @@ maintainer="Zextras <packages@zextras.com"
 url="https://zextras.com"
 section="libs"
 priority="important"
+makedepends=(
+  "autoconf"
+  "automake"
+  "libtool"
+)
 source=(
   "https://archive.mozilla.org/pub/opus/opus-${pkgver}.tar.gz"
 )
@@ -18,6 +23,7 @@ sha256sums=('65b58e1e25b2a114157014736a3d9dfeaad8d41be1c8179866f144a2fb44ff9d')
 
 build() {
   cd "${srcdir}/opus-${pkgver}"
+  export CFLAGS="${CFLAGS} -ffile-prefix-map=${srcdir}=."
   export LDFLAGS="-Wl,-rpath,/opt/zextras/common/lib"
   export PKG_CONFIG_PATH="/opt/zextras/common/lib/pkgconfig"
 
@@ -26,7 +32,7 @@ build() {
     --disable-static \
     --enable-custom-modes \
     --prefix=/opt/zextras/common
-  make -j8
+  make -j"$(( $(nproc) / 2 ))"
 }
 
 package() {

--- a/videoserver/librabbitmq-c/PKGBUILD
+++ b/videoserver/librabbitmq-c/PKGBUILD
@@ -11,19 +11,11 @@ maintainer="Zextras <packages@zextras.com"
 url="https://zextras.com"
 section="libs"
 priority="important"
-depends__apt=(
+depends=(
   "carbonio-openssl"
 )
-makedepends__apt=(
+makedepends=(
   "cmake"
-  "carbonio-openssl"
-)
-depends__yum=(
-  "carbonio-openssl"
-)
-makedepends__yum=(
-  "cmake"
-  "carbonio-openssl"
 )
 
 section="libs"
@@ -34,7 +26,7 @@ source=(
 sha256sums=('437d45e0e35c18cf3e59bcfe5dfe37566547eb121e69fca64b98f5d2c1c2d424')
 
 build() {
-  export CFLAGS="-I/opt/zextras/common/include"
+  export CFLAGS="-I/opt/zextras/common/include -ffile-prefix-map=${srcdir}=."
   export LDFLAGS="-Wl,-rpath,/opt/zextras/common/lib"
   export PKG_CONFIG_PATH="/opt/zextras/common/lib/pkgconfig"
 
@@ -53,7 +45,7 @@ build() {
     -B build \
     -S "rabbitmq-c-${pkgver}"
 
-  make -C build
+  make -C build -j"$(( $(nproc) / 2 ))"
 }
 
 package() {

--- a/videoserver/libsrtp/PKGBUILD
+++ b/videoserver/libsrtp/PKGBUILD
@@ -12,9 +12,6 @@ url="https://zextras.com"
 depends=(
   "carbonio-openssl"
 )
-makedepends=(
-  "carbonio-openssl"
-)
 section="libs"
 priority="important"
 source=(
@@ -24,14 +21,15 @@ sha256sums=('dcb374501166f9699ef2e7ad5433a79fb04bf229544cfff2bcd55156be4456b8')
 
 build() {
   cd "${srcdir}/libsrtp-bd0f27ec0e299ad101a396dde3f7c90d48efc8fc"
+  export CFLAGS="${CFLAGS} -ffile-prefix-map=${srcdir}=."
   export LDFLAGS="-Wl,-rpath,/opt/zextras/common/lib"
   export PKG_CONFIG_PATH="/opt/zextras/common/lib/pkgconfig"
 
   ./configure \
     --enable-openssl \
     --prefix=/opt/zextras/common
-  make all
-  make shared_library
+  make all -j"$(( $(nproc) / 2 ))"
+  make shared_library -j"$(( $(nproc) / 2 ))"
 }
 
 package() {

--- a/videoserver/libusrsctp/PKGBUILD
+++ b/videoserver/libusrsctp/PKGBUILD
@@ -12,6 +12,8 @@ url="https://zextras.com"
 section="libs"
 priority="important"
 makedepends=(
+  "autoconf"
+  "automake"
   "libtool"
 )
 source=(
@@ -21,12 +23,13 @@ sha256sums=('8970528ced951650879a14aa60b65190c09cea6bbc70a8fc11154d17c9ca82aa')
 
 build() {
   cd "${srcdir}/usrsctp-a0cbf4681474fab1e89d9e9e2d5c3694fce50359"
+  export CFLAGS="${CFLAGS} -ffile-prefix-map=${srcdir}=."
   export LDFLAGS="-Wl,-rpath,/opt/zextras/common/lib"
   ./bootstrap
   ./configure \
     --disable-debug \
     --prefix=/opt/zextras/common
-  make -j8
+  make -j"$(( $(nproc) / 2 ))"
 }
 
 package() {

--- a/videoserver/libuv/PKGBUILD
+++ b/videoserver/libuv/PKGBUILD
@@ -17,6 +17,11 @@ depends__yum=(
   "glibc"
 )
 
+makedepends=(
+  "autoconf"
+  "automake"
+  "libtool"
+)
 section="libs"
 priority="important"
 source=(
@@ -26,11 +31,12 @@ sha256sums=('ccfcdc968c55673c6526d8270a9c8655a806ea92468afcbcabc2b16040f03cb4')
 
 build() {
   cd "${srcdir}/libuv-v${pkgver}"
+  export CFLAGS="${CFLAGS} -ffile-prefix-map=${srcdir}=."
   export LDFLAGS="-Wl,-rpath,/opt/zextras/common/lib"
   export PKG_CONFIG_PATH="/opt/zextras/common/lib/pkgconfig"
   ./autogen.sh
   ./configure --prefix=/opt/zextras/common
-  make -j8
+  make -j"$(( $(nproc) / 2 ))"
 }
 
 package() {

--- a/videoserver/libvpx/PKGBUILD
+++ b/videoserver/libvpx/PKGBUILD
@@ -21,6 +21,8 @@ sha256sums=('00dae80465567272abd077f59355f95ac91d7809a2d3006f9ace2637dd429d14')
 
 build() {
   cd "${srcdir}/libvpx-${pkgver}"
+  export CFLAGS="${CFLAGS} -ffile-prefix-map=${srcdir}=."
+  export CXXFLAGS="${CXXFLAGS} -ffile-prefix-map=${srcdir}=."
   export LDFLAGS="-Wl,-rpath,/opt/zextras/common/lib"
 
   ./configure \
@@ -36,7 +38,7 @@ build() {
     --enable-vp9-highbitdepth \
     --enable-vp9-temporal-denoising \
     --prefix=/opt/zextras/common
-  make -j8
+  make -j"$(( $(nproc) / 2 ))"
 }
 
 package() {

--- a/videoserver/libwebsockets/PKGBUILD
+++ b/videoserver/libwebsockets/PKGBUILD
@@ -16,12 +16,12 @@ depends=(
 )
 makedepends__apt=(
   "cmake"
-  "carbonio-openssl"
+  "libglib2.0-dev"
   "zlib1g-dev"
 )
 makedepends__yum=(
-  "carbonio-openssl"
   "cmake"
+  "glib2-devel"
   "libuv"
   "zlib-devel"
 )
@@ -35,6 +35,7 @@ sha256sums=('6fd33527b410a37ebc91bb64ca51bdabab12b076bc99d153d7c5dd405e4bdf90')
 
 build() {
   cd "${srcdir}"
+  export CFLAGS="${CFLAGS} -ffile-prefix-map=${srcdir}=."
   mkdir build || true
   cmake \
     -D CMAKE_INSTALL_PREFIX=/opt/zextras/common \
@@ -77,7 +78,7 @@ build() {
     -B build \
     -S "libwebsockets-${pkgver}"
 
-  make -C build -j8
+  make -C build -j"$(( $(nproc) / 2 ))"
 }
 
 package() {

--- a/videoserver/mlt/PKGBUILD
+++ b/videoserver/mlt/PKGBUILD
@@ -15,8 +15,6 @@ depends=(
   'carbonio-libxml2'
 )
 makedepends=(
-  'carbonio-ffmpeg'
-  'carbonio-libxml2'
   'cmake'
 )
 provides__ubuntu_focal=(
@@ -52,7 +50,7 @@ source=("https://github.com/mltframework/mlt/releases/download/v${pkgver}/mlt-${
 sha256sums=('8a484bbbf51f33e25312757531f3ad2ce20607149d20fcfcb40a3c1e60b20b4e')
 
 build() {
-  export CFLAGS="-I/opt/zextras/common/include"
+  export CFLAGS="-I/opt/zextras/common/include -ffile-prefix-map=${srcdir}=."
   export LDFLAGS="-Wl,-rpath,/opt/zextras/common/lib"
   export PKG_CONFIG_PATH="/opt/zextras/common/lib/pkgconfig"
 

--- a/videoserver/x264/PKGBUILD
+++ b/videoserver/x264/PKGBUILD
@@ -23,6 +23,7 @@ sha256sums=('d053c9d86988d6bc78237ca5205865c5ddf99c98ef4cd9927eec8f6d388f6dd9')
 
 build() {
   cd "${srcdir}/x264-31e19f92f00c7003fa115047ce50978bc98c3a0d"
+  export CFLAGS="${CFLAGS} -ffile-prefix-map=${srcdir}=."
   ./version.sh | grep X264_POINTVER | sed -r 's/^#define X264_POINTVER "([0-9]+\.[0-9]+)\.([0-9]+) (.*)"$/\1.r\2.\3/'
 
   ./configure \
@@ -31,7 +32,7 @@ build() {
     --enable-pic \
     --enable-shared \
     --prefix=/opt/zextras/common
-  make -j8
+  make -j"$(( $(nproc) / 2 ))"
 }
 
 package() {


### PR DESCRIPTION
Add missing build dependencies (autoconf, automake, libtool, nasm, glib2-dev) identified by comparing with Arch Linux PKGBUILDs, and add -ffile-prefix-map reproducibility flag to all packages.