### PR TITLE
ci: update jenkins-lib-common to v2.11.2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 library(
-    identifier: 'jenkins-lib-common@1.7.5',
+    identifier: 'jenkins-lib-common@v2.11.2',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',
@@ -34,10 +34,18 @@ pipeline {
     stage('Setup') {
       steps {
         checkout scm
-        script {
-          gitMetadata()
-        }
+        gitMetadata()
       }
+    }
+
+    stage('Skip CI') {
+      steps {
+        script { semanticRelease.guard() }
+      }
+    }
+
+    stage('Security Scan') {
+      steps { gitleaksStage() }
     }
 
     stage('Build deb/rpm') {
@@ -65,9 +73,7 @@ pipeline {
         jfrog 'jfrog-cli'
       }
       steps {
-        uploadStage([
-          packages: yapHelper.getPackageNames()
-        ])
+        uploadStage()
       }
       post {
         failure {
@@ -77,6 +83,12 @@ pipeline {
             }
           }
         }
+      }
+    }
+
+    stage('Semantic Release') {
+      steps {
+        semanticRelease()
       }
     }
   }


### PR DESCRIPTION
## Summary

- Bump `jenkins-lib-common` to `v2.11.2`
- Remove deprecated `packages:` parameter from `uploadStage()` (breaking change: now resolved internally from PKGBUILDs)
- Move `gitMetadata()` to top-level step in Setup stage (out of `script {}`)
- Add `Security Scan` stage with `gitleaksStage()`
- Add `Skip CI` stage with `semanticRelease.guard()`
- Add `Semantic Release` stage with `semanticRelease()`

## Checklist
- [x] Library version bumped to v2.11.2
- [x] No `packages:` in uploadStage calls
- [x] No `uploadStage.shouldUpload()` when-guard
- [x] No `dt2_semanticRelease()`
- [x] `gitMetadata()` is top-level step in Setup
- [x] Semantic release stages added